### PR TITLE
Added sfcontrollera snippet.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,28 @@ class ControllerNameController extends Controller
 }
 ```
 
+`sfcontrollera`
+
+``` php
+namespace VendorName\Bundle\BundleNameBundle\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
+
+class ControllerNameController extends Controller
+{
+    /**
+     * @Route(route configuration)
+     * @Template
+     */
+    public function indexAction()
+    {
+
+    }
+}
+```
+
 `sfem`
 
 ``` php

--- a/Snippets/Controller/controllerclass-annotated.sublime-snippet
+++ b/Snippets/Controller/controllerclass-annotated.sublime-snippet
@@ -1,0 +1,23 @@
+<snippet>
+    <content><![CDATA[namespace ${1:VendorName}\\Bundle\\${2:BundleName}Bundle\\Controller;
+
+use Symfony\\Bundle\\FrameworkBundle\\Controller\\Controller;
+use Sensio\\Bundle\\FrameworkExtraBundle\\Configuration\\Route;
+use Sensio\\Bundle\\FrameworkExtraBundle\\Configuration\\Template;
+
+class ${3:ControllerName}Controller extends Controller
+{
+    /**
+     * @Route(${4:route configuration})
+     * @Template
+     */
+    public function ${5:index}Action()
+    {
+        ${0}
+    }
+}
+]]></content>
+    <tabTrigger>sfcontrollera</tabTrigger>
+    <scope>source.php</scope>
+    <description>Symfony2 / Controller / Annotated controller class</description>
+</snippet>


### PR DESCRIPTION
Hey,

I just added a snippet to make an annotated controller because I created a lot of these recently.

The "tabTrigger" I used is "sfcontrollera" : I appended a "a" for "annotated" after "sfcontroller".
I don't know if it's a good idea. The goal was to type the fewest possible characters but if you find it too close to "sfcontroller", I'm open to any other suggestion.
