### PR TITLE
Form type - Replace deprecated setDefaultOptions

### DIFF
--- a/Snippets/Form/formtype.sublime-snippet
+++ b/Snippets/Form/formtype.sublime-snippet
@@ -2,7 +2,7 @@
     <content><![CDATA[
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ${1:Name}Type extends AbstractType
 {
@@ -17,7 +17,7 @@ class ${1:Name}Type extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function setDefaultOptions(OptionsResolverInterface \$resolver)
+    public function configureOptions(OptionsResolver \$resolver)
     {
         \$resolver->setDefaults(array(${2:
             'data_class' => '${3}',


### PR DESCRIPTION
Updated form type snippet replacing the deprecated method setDefaultOptions by configureOptions