### PR TITLE
Remove sfgetset setter return type

### DIFF
--- a/Snippets/Doctrine/Classes/getset.sublime-snippet
+++ b/Snippets/Doctrine/Classes/getset.sublime-snippet
@@ -10,7 +10,7 @@ public function get${1/(.*)/\u$1/}()
 
 /**
 * Set $1
-* @return $2 
+* @return \$this
 */
 public function set${1/(.*)/\u$1/}(\$$1)
 {


### PR DESCRIPTION
The setter returns the class, not the field type.