### PR TITLE
Update manytoone snippet

### DIFF
--- a/Snippets/Doctrine/Annotations/column_manytoone.sublime-snippet
+++ b/Snippets/Doctrine/Annotations/column_manytoone.sublime-snippet
@@ -1,8 +1,8 @@
 <snippet>
     <content><![CDATA[
 /**
- * @ORM\ManyToOne(targetEntity="$2")
- * @ORM\JoinColumn(name="${4:${1/([[:upper:]]+)/(?1_\l$1:)/g}}", referencedColumnName="${3:id}"$5)
+ * @ORM\ManyToOne(targetEntity="$3")
+ * @ORM\JoinColumn(name="${5:${1/([[:upper:]]+)/(?1_\l$1:)/g}}", referencedColumnName="${4:id}"$6)
  */
  ${2:private} \$${1:$SELECTION};
 ]]></content>


### PR DESCRIPTION
When using ManyToOne doctrine snippet, the targetEntity was tied to the visibility keyword creating fields like:

```
    /**
     * @ORM\ManyToOne(targetEntity="private")
     * @ORM\JoinColumn(name="test", referencedColumnName="id")
     */
     private $test;
```

or 

```
    /**
     * @ORM\ManyToOne(targetEntity="MyEntity")
     * @ORM\JoinColumn(name="test", referencedColumnName="id")
     */
     MyEntity $test;
```

Now you can do this:

```
    /**
     * @ORM\ManyToOne(targetEntity="MyEntity")
     * @ORM\JoinColumn(name="test", referencedColumnName="id")
     */
     private $test;
```
